### PR TITLE
Add section on evolving AI-assisted development tools

### DIFF
--- a/docs/presentations/modules/part1/00-kickoff-and-setup.md
+++ b/docs/presentations/modules/part1/00-kickoff-and-setup.md
@@ -37,7 +37,7 @@ backgroundColor: #fff
 - Training content reflects current features; some may vary by tool
 - Embrace a growth mindset and have fun!
 
-___
+---
 
 # Why This Workshop Matters
 

--- a/docs/presentations/modules/part1/00-kickoff-and-setup.md
+++ b/docs/presentations/modules/part1/00-kickoff-and-setup.md
@@ -31,7 +31,7 @@ backgroundColor: #fff
 ## The only constant is change
 
 - Copilot is available in multiple IDEs, github.com, CLI, and mobile - features vary by tool
-- What you see in VS 2022/2026 may differ from VS Code or other IDEs
+- What you see in Visual Studio 2022 or 2026 may differ from VS Code or other tools
   - See [Copilot feature matrix](https://docs.github.com/en/copilot/reference/copilot-feature-matrix) for version details
 - AI agentic software engineering technology and practices are evolving quickly — expect changes and differences
 - Training content reflects current features; some may vary by tool

--- a/docs/presentations/modules/part1/00-kickoff-and-setup.md
+++ b/docs/presentations/modules/part1/00-kickoff-and-setup.md
@@ -28,6 +28,17 @@ backgroundColor: #fff
 
 ---
 
+## The only constant is change
+
+- Copilot is available in multiple IDEs, github.com, CLI, and mobile - features vary by tool
+- What you see in VS 2022/2026 may differ from VS Code or other IDEs
+  - See [Copilot feature matrix](https://docs.github.com/en/copilot/reference/copilot-feature-matrix) for version details
+- AI agentic software engineering technology and practices are evolving quickly — expect changes and differences
+- Training content reflects current features; some may vary by tool
+- Embrace a growth mindset and have fun!
+
+___
+
 # Why This Workshop Matters
 
 **Traditional Development:**

--- a/docs/presentations/modules/part1/00-kickoff-and-setup.md
+++ b/docs/presentations/modules/part1/00-kickoff-and-setup.md
@@ -30,7 +30,7 @@ backgroundColor: #fff
 
 ## The only constant is change
 
-- Copilot is available in multiple IDEs, github.com, CLI, and mobile - features vary by tool
+- Copilot is available in multiple IDEs, GitHub.com, CLI, and mobile — features vary by tool
 - What you see in Visual Studio 2022 or 2026 may differ from VS Code or other tools
   - See [Copilot feature matrix](https://docs.github.com/en/copilot/reference/copilot-feature-matrix) for version details
 - AI agentic software engineering technology and practices are evolving quickly — expect changes and differences

--- a/docs/presentations/modules/part1/00-kickoff-and-setup.md
+++ b/docs/presentations/modules/part1/00-kickoff-and-setup.md
@@ -33,7 +33,7 @@ backgroundColor: #fff
 - Copilot is available in multiple IDEs, GitHub.com, CLI, and mobile — features vary by tool
 - What you see in Visual Studio 2022 or 2026 may differ from VS Code or other tools
   - See [Copilot feature matrix](https://docs.github.com/en/copilot/reference/copilot-feature-matrix) for version details
-- AI agentic software engineering technology and practices are evolving quickly — expect changes and differences
+- AI-assisted software engineering tools and practices are evolving quickly — expect changes and differences
 - Training content reflects current features; some may vary by tool
 - Embrace a growth mindset and have fun!
 


### PR DESCRIPTION
This pull request adds a new introductory section to the kickoff and setup module of the presentation, emphasizing the evolving nature of Copilot features and encouraging a growth mindset.

Key documentation update:

* Added a "The only constant is change" section to `00-kickoff-and-setup.md` that highlights differences across Copilot tools, points to the official feature matrix, and sets expectations for rapidly changing technology and training content.