### PR TITLE
chore: remove bierner.markdown-mermaid extension from all devcontainers

### DIFF
--- a/.devcontainer/dotnet-participant/devcontainer.json
+++ b/.devcontainer/dotnet-participant/devcontainer.json
@@ -21,7 +21,6 @@
                 "GitHub.copilot-chat",
                 "humao.rest-client",
                 "ms-dotnettools.csdevkit",
-                "bierner.markdown-mermaid",
                 "marp-team.marp-vscode",
                 "yzhang.markdown-all-in-one"
             ],

--- a/.devcontainer/maintainer/devcontainer.json
+++ b/.devcontainer/maintainer/devcontainer.json
@@ -56,7 +56,6 @@
                 "humao.rest-client",
                 
                 // Documentation & Presentations
-                "bierner.markdown-mermaid",
                 "marp-team.marp-vscode",
                 "yzhang.markdown-all-in-one"
             ],

--- a/.devcontainer/springboot-participant/devcontainer.json
+++ b/.devcontainer/springboot-participant/devcontainer.json
@@ -33,7 +33,6 @@
                 "vmware.vscode-spring-boot",
                 "vscjava.vscode-maven",
                 "vscjava.vscode-gradle",
-                "bierner.markdown-mermaid",
                 "marp-team.marp-vscode",
                 "yzhang.markdown-all-in-one"
             ],


### PR DESCRIPTION
Removes the `bierner.markdown-mermaid` VS Code extension from all three devcontainer configurations:
- `.devcontainer/dotnet-participant/devcontainer.json`
- `.devcontainer/maintainer/devcontainer.json`
- `.devcontainer/springboot-participant/devcontainer.json`